### PR TITLE
Replace mod name spaces with dash

### DIFF
--- a/src/main/java/net/caffeinemc/caffeineconfig/CaffeineConfig.java
+++ b/src/main/java/net/caffeinemc/caffeineconfig/CaffeineConfig.java
@@ -48,8 +48,8 @@ public final class CaffeineConfig {
      */
     public static CaffeineConfig.Builder builder(String modName) {
         CaffeineConfig config = new CaffeineConfig(modName);
-        config.logger = LogManager.getLogger(modName + "Config");
-        String jsonKey = modName.toLowerCase() + ":options";
+        config.logger = LogManager.getLogger(modName + " Config");
+        String jsonKey = modName.toLowerCase().replace(" ", "-") + ":options";
         return config.new Builder().withSettingsKey(jsonKey);
     }
 


### PR DESCRIPTION
- Adds the missing space for the logger.
- ~~Replaces any whitespaces with a dash for our JSON key.~~

Todo:
- Sanitize any non-alphanumeric characters for mod name or just swap out for mod identifier.